### PR TITLE
feat: expire time 구현

### DIFF
--- a/src/redux/sagas.ts
+++ b/src/redux/sagas.ts
@@ -13,7 +13,7 @@ function* fetchData(action: ReturnType<typeof changeInput>) {
     )
     if (!cachedData) {
       const response: AxiosResponse<SickResponseData> = yield sick.getSick(action.payload)
-      console.log('api called!')
+      console.info('calling api')
       if (response.config.url) {
         setCache(response.config.url, response)
       }

--- a/src/redux/sagas.ts
+++ b/src/redux/sagas.ts
@@ -13,13 +13,9 @@ function* fetchData(action: ReturnType<typeof changeInput>) {
     )
     if (!cachedData) {
       const response: AxiosResponse<SickResponseData> = yield sick.getSick(action.payload)
+      console.log('api called!')
       if (response.config.url) {
-        const myResponse = new Response(JSON.stringify(response.data), {
-          headers: {
-            'Content-Type': 'application/json; charset=utf-8',
-          },
-        })
-        setCache(response.config.url, myResponse)
+        setCache(response.config.url, response)
       }
       yield put(setSick(response.data))
     } else {
@@ -31,7 +27,7 @@ function* fetchData(action: ReturnType<typeof changeInput>) {
 }
 
 function* watchChangeInput() {
-  yield debounce(500, changeInput.type, fetchData)
+  yield debounce(1000, changeInput.type, fetchData)
 }
 
 export default function* rootSaga() {

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,12 +1,41 @@
+import { AxiosResponse } from 'axios'
+
 const CACHE_NAME = 'sicks'
 
-export const setCache = async (request: RequestInfo | URL, response: Response) => {
+// 캐시타임 기본 20초
+const EXPIRE_TIME = 200000
+
+export const setCache = async (
+  request: RequestInfo | URL,
+  axiosResponse: AxiosResponse,
+  expireTime = EXPIRE_TIME,
+) => {
+  const expireDate = new Date().getTime() + expireTime
+  const response = new Response(JSON.stringify(axiosResponse.data), {
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'EXPIRE-DATE': `${expireDate}`,
+    },
+  })
+
   const cache = await caches.open(CACHE_NAME)
   await cache.put(request, response)
 }
 
 export const getCache = async (request: RequestInfo | URL) => {
+  const nowTime = new Date().getTime()
   const cache = await caches.open(CACHE_NAME)
   const response = await cache.match(request)
-  return await response?.json()
+
+  if (!response) return
+
+  const dueTime = Number(response.headers.get('EXPIRE-DATE'))
+
+  if (dueTime - nowTime < 0) {
+    await cache.delete(request)
+    console.log('cache deleted')
+    return
+  }
+
+  return await response.json()
 }

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -3,7 +3,7 @@ import { AxiosResponse } from 'axios'
 const CACHE_NAME = 'sicks'
 
 // 캐시타임 기본 20초
-const EXPIRE_TIME = 200000
+const EXPIRE_TIME = 20 * 1000
 
 export const setCache = async (
   request: RequestInfo | URL,

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -33,7 +33,7 @@ export const getCache = async (request: RequestInfo | URL) => {
 
   if (dueTime - nowTime < 0) {
     await cache.delete(request)
-    console.log('cache deleted')
+    console.info('cache deleted')
     return
   }
 


### PR DESCRIPTION
# PR

## 🗄️ 종류

PR 종류를 선택하세요

- [ ] Code Review
- [x] New Feature
- [ ] Remove Feature
- [x] Change Logic
- [ ] Bug Fix
- [ ] Setup

<br>

## 🗜️ 새로 설치한 페키지

-

## 🔍 왜 변경을 했습니까?
로컬 캐싱에서 expire time을 구현하기 위해 변경했습니다.

<br>

## 🔧 작업 내용

> setCache 함수 

expireTIme을 인자로 받아 현재시간에 더하여 헤더에 EXPIRE-DATE의 value로 넣어줍니다.

> getCache 함수 

- 캐시값이 없으면 : 캐시된 데이터를 검색하여 검색값이 없으면 undefind를 리턴합니다.<br/>
- 캐시 값이 있으면:  
  - EXPIRE-DATE가 더 크면(데이터가 유효하지 않으면): 캐시값이 있으면 캐시값의 헤더에 들어있는 EXPIRE-DATE와 현재 시간을 비교하고 현재 시간이 더 크면 undefinde를 리턴합니다. 
  - EXPIRE-DATE가 작으면(아직 데이터가 유효하면): 캐시된 데이터를 리턴합니다.


<br>

## 📷 스크린샷

<br>

## 📝 리뷰할 때 참고할 점

- 기본값으로 20초로 설정하려고 했는데 실수로 200초로 설정했습니다.
